### PR TITLE
Make PromisedAssertion an intersection type alias

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,8 +58,7 @@ declare namespace ChaiPromised {
         members: PromisedMembers;
     }
 
-    interface PromisedAssertion extends Eventually, Promise<any> {
-    }
+    type PromisedAssertion = Eventually & Promise<any>
 
     interface PromisedLanguageChains {
         eventually: Eventually;


### PR DESCRIPTION
Fixes #1 by not extending two incompatible interfaces, but rather making `PromisedAssertions` an intersection type of `Eventually` and `Promise<any>`.

Tested by sourcing the typings in my project from this branch instead of `registry:npm/chai-as-promised`.

I can't get your tests to work on my machine, it would be great if you could check whether this works for you as well.
